### PR TITLE
Increase limits for phase durations in stimulation dialog window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+* Increase limits for phase durations in stimulation dialog window ([#1][pr-1])
+    * First and second phase durations were capped at 5 ms each. These were
+      increased to allow for the longest possible pulses permitted by the
+      hardware (~2-3 seconds, depending on sampling period).
+
+[pr-1]: https://github.com/CWRUChielLab/IntanStimRecordController/pull/1

--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,9 @@
-Intan Stimulation/Recording Controller Software - Source Code (v1.07)
----------------------------------------------------------------------
+Intan Stimulation/Recording Controller Software - Source Code (v1.07 - modified)
+--------------------------------------------------------------------------------
+
+NOTE: This software has been modified from the version provided by the
+manufacturer. See CHANGELOG.md for details. Notes for building can be found
+here: https://github.com/CWRUChielLab/IntanStimRecordController/wiki
 
 This directory contains the Intan Stimulation/Recording Controller C++/Qt source code and two supporting files:
 main.bit (the FPGA configuration file) and an operating system-specific Opal Kelly library file located
@@ -16,7 +20,7 @@ connecting the Intan Recording Controller to a computer.  (They are not included
 However, you can run the Recording Controller software in demonstration mode without installing drivers
 or plugging in an interface board.
 
-The C++ source code uses a handful of C++11 features, so g++ users may need to add -std=c++11 to their 
+The C++ source code uses a handful of C++11 features, so g++ users may need to add -std=c++11 to their
 command line or make file.
 
 This code was tested with Qt 4.8.1 and with Qt 5.7.0.
@@ -25,7 +29,7 @@ For production code, you should compile a Release build (Visual Studio) or use t
 -O3 (g++).  Otherwise, the compiled code may not be fast enough to keep up with how fast data streams
 from the USB interface board.  This will show up as the FIFO lag becoming very high for debug builds.
 
-(Thanks to Josh Siegle at MIT and Open-Ephys.org for tips on Mac and Linux compilation.) 
+(Thanks to Josh Siegle at MIT and Open-Ephys.org for tips on Mac and Linux compilation.)
 
 Other Linux tips
 ----------------
@@ -56,7 +60,7 @@ code on a Mac.  This description is based on exprience using a MacBook Pro runni
 
 -------------------------------------------------------------------------
 
-Some Windows users have reported that it is necessary to install Qt with 32-bit support for the 
+Some Windows users have reported that it is necessary to install Qt with 32-bit support for the
 okFrontPanel DLL to load properly.  But this was with an older version of the Recording Controller source
 code that didn't support 64-bit, so it may not apply any more.
 

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -4804,6 +4804,27 @@ void MainWindow::setStimSequenceParameters(Rhs2000EvalBoard *evalBoard, double t
         eventChargeRecovOff = 0;
     }
 
+    //warn if events have exceeded the max time
+    if (eventStartStim > NEVER ||
+        eventStimPhase2 > NEVER ||
+        eventStimPhase3 > NEVER ||
+        eventEndStim > NEVER ||
+        eventRepeatStim > NEVER ||
+        eventEnd > NEVER ||
+        eventAmpSettleOn > NEVER ||
+        eventAmpSettleOff > NEVER ||
+        eventAmpSettleOnRepeat > NEVER ||
+        eventAmpSettleOffRepeat > NEVER ||
+        eventChargeRecovOn > NEVER ||
+        eventChargeRecovOff > NEVER)
+    {
+        QMessageBox::critical(this, tr("Stimulation Pulse Duration Exceeds Hardware Limitation"),
+                                    tr("WARNING: The selected stimulation parameters define a pulse that is longer "
+                                       "than what the hardware can produce. If you do not reduce the pulse duration, "
+                                       "the hardware is likely to execute the wrong stimulation protocol!"),
+                                    QMessageBox::Ok);
+    }
+
     evalBoard->programStimReg(stream, channel, Rhs2000EvalBoard::EventAmpSettleOn, eventAmpSettleOn);
     evalBoard->programStimReg(stream, channel, Rhs2000EvalBoard::EventStartStim, eventStartStim);
     evalBoard->programStimReg(stream, channel, Rhs2000EvalBoard::EventStimPhase2, eventStimPhase2);

--- a/source/stimparamdialog.cpp
+++ b/source/stimparamdialog.cpp
@@ -61,11 +61,11 @@ StimParamDialog::StimParamDialog(StimParameters *parameter, QString nativeChanne
 
     firstPhaseDurationLabel = new QLabel(tr("First Phase Duration (D1): "));
     firstPhaseDuration = new TimeSpinBox(timestep_us);
-    firstPhaseDuration->setRange(0, 100000000000);
+    firstPhaseDuration->setRange(0, 5000);
 
     secondPhaseDurationLabel = new QLabel(tr("Second Phase Duration (D2): "));
     secondPhaseDuration = new TimeSpinBox(timestep_us);
-    secondPhaseDuration->setRange(0, 100000000000);
+    secondPhaseDuration->setRange(0, 5000);
 
     interphaseDelayLabel = new QLabel(tr("Interphase Delay (DP): "));
     interphaseDelay = new TimeSpinBox(timestep_us);
@@ -139,7 +139,7 @@ StimParamDialog::StimParamDialog(StimParameters *parameter, QString nativeChanne
 
     numberOfStimPulsesLabel = new QLabel(tr("Number of Stim Pulses"));
     numberOfStimPulses = new QSpinBox();
-    numberOfStimPulses->setRange(2, 1000000000);
+    numberOfStimPulses->setRange(2, 256);
 
     pulseTrainPeriodLabel = new QLabel(tr("Pulse Train Period: "));
     pulseTrainPeriod = new TimeSpinBox(timestep_us);

--- a/source/stimparamdialog.cpp
+++ b/source/stimparamdialog.cpp
@@ -61,11 +61,11 @@ StimParamDialog::StimParamDialog(StimParameters *parameter, QString nativeChanne
 
     firstPhaseDurationLabel = new QLabel(tr("First Phase Duration (D1): "));
     firstPhaseDuration = new TimeSpinBox(timestep_us);
-    firstPhaseDuration->setRange(0, 5000);
+    firstPhaseDuration->setRange(0, 100000000000);
 
     secondPhaseDurationLabel = new QLabel(tr("Second Phase Duration (D2): "));
     secondPhaseDuration = new TimeSpinBox(timestep_us);
-    secondPhaseDuration->setRange(0, 5000);
+    secondPhaseDuration->setRange(0, 100000000000);
 
     interphaseDelayLabel = new QLabel(tr("Interphase Delay (DP): "));
     interphaseDelay = new TimeSpinBox(timestep_us);
@@ -139,7 +139,7 @@ StimParamDialog::StimParamDialog(StimParameters *parameter, QString nativeChanne
 
     numberOfStimPulsesLabel = new QLabel(tr("Number of Stim Pulses"));
     numberOfStimPulses = new QSpinBox();
-    numberOfStimPulses->setRange(2, 256);
+    numberOfStimPulses->setRange(2, 1000000000);
 
     pulseTrainPeriodLabel = new QLabel(tr("Pulse Train Period: "));
     pulseTrainPeriod = new TimeSpinBox(timestep_us);
@@ -919,10 +919,10 @@ void StimParamDialog::roundTimeInputs()
     //refractoryPeriod
     refractoryPeriod->round();
 
-    //preStimAmpSettle   
+    //preStimAmpSettle
     preStimAmpSettle->round();
 
-    //postStimAmpSettle    
+    //postStimAmpSettle
     postStimAmpSettle->round();
 
     //postStimChargeRecovOn

--- a/source/stimparamdialog.cpp
+++ b/source/stimparamdialog.cpp
@@ -867,32 +867,40 @@ void StimParamDialog::constrainRefractoryPeriod()
     refractoryPeriod->setTrueMinimum(qMax(postStimAmpSettle->getTrueValue(), postStimChargeRecovOff->getTrueValue()));
 }
 
-/* Private slot that constrains pulseTrainPeriod's lowest possible value to the sum of the durations of active phases */
-void StimParamDialog::constrainPulseTrainPeriod()
+
+/* Private method for calculating the total duration of the waveform */
+double StimParamDialog::calculateWaveformDuration()
 {
-    double minimum;
+    double waveformDuration;
     //if biphasic
     if (stimShape->currentIndex() == StimParameters::Biphasic)
     {
-        //minimum equals D1 + D2
-        minimum = firstPhaseDuration->getTrueValue() + secondPhaseDuration->getTrueValue();
+        //duration equals D1 + D2
+        waveformDuration = firstPhaseDuration->getTrueValue() + secondPhaseDuration->getTrueValue();
     }
 
     //if biphasic with interphase delay
     else if (stimShape->currentIndex() == StimParameters::BiphasicWithInterphaseDelay)
     {
-        //minimum equals D1 + D2 + D_int
-        minimum = firstPhaseDuration->getTrueValue() + secondPhaseDuration->getTrueValue() + interphaseDelay->getTrueValue();
+        //duration equals D1 + D2 + D_int
+        waveformDuration = firstPhaseDuration->getTrueValue() + secondPhaseDuration->getTrueValue() + interphaseDelay->getTrueValue();
     }
 
     //if triphasic
     else if (stimShape->currentIndex() == StimParameters::Triphasic)
     {
-        //minimum equals 2*D1 + D2
-        minimum = (2 * firstPhaseDuration->getTrueValue()) + secondPhaseDuration->getTrueValue();
+        //duration equals 2*D1 + D2
+        waveformDuration = (2 * firstPhaseDuration->getTrueValue()) + secondPhaseDuration->getTrueValue();
     }
 
-    pulseTrainPeriod->setTrueMinimum(minimum);
+    return waveformDuration;
+}
+
+
+/* Private slot that constrains pulseTrainPeriod's lowest possible value to the sum of the durations of active phases */
+void StimParamDialog::constrainPulseTrainPeriod()
+{
+    pulseTrainPeriod->setTrueMinimum(calculateWaveformDuration());
 }
 
 

--- a/source/stimparamdialog.cpp
+++ b/source/stimparamdialog.cpp
@@ -602,6 +602,14 @@ void StimParamDialog::loadParameters(StimParameters *parameters)
 /* Public slot that saves the values from the dialog box widgets into the parameters object, and closes the window */
 void StimParamDialog::accept()
 {
+    if (calculateActualSinglePulseDuration() > maxPulseDuration_us) {
+        QMessageBox::warning(this, tr("Single pulse duration is too long"),
+                                tr("The single pulse duration exceeds hardware limitations. "
+                                   "You must reduce the duration before you can save these settings."),
+                                QMessageBox::Ok);
+        return;
+    }
+
     //save the values of the parameters from the dialog box into the object
     parameters->stimShape = (StimParameters::StimShapeValues) stimShape->currentIndex();
     parameters->stimPolarity = (StimParameters::StimPolarityValues) stimPolarity->currentIndex();

--- a/source/stimparamdialog.cpp
+++ b/source/stimparamdialog.cpp
@@ -40,6 +40,9 @@ StimParamDialog::StimParamDialog(StimParameters *parameter, QString nativeChanne
     timestep = timestep_us;
     currentstep = currentstep_uA;
 
+    //maximum duration of a single pulse is hardware limited to timestep * (2^16 - 1)
+    maxPulseDuration_us = timestep_us * 65535;
+
     //create a new StimFigure
     stimFigure = new StimFigure(parameters, this);
 
@@ -61,11 +64,11 @@ StimParamDialog::StimParamDialog(StimParameters *parameter, QString nativeChanne
 
     firstPhaseDurationLabel = new QLabel(tr("First Phase Duration (D1): "));
     firstPhaseDuration = new TimeSpinBox(timestep_us);
-    firstPhaseDuration->setRange(0, 5000);
+    firstPhaseDuration->setRange(0, maxPulseDuration_us);
 
     secondPhaseDurationLabel = new QLabel(tr("Second Phase Duration (D2): "));
     secondPhaseDuration = new TimeSpinBox(timestep_us);
-    secondPhaseDuration->setRange(0, 5000);
+    secondPhaseDuration->setRange(0, maxPulseDuration_us);
 
     interphaseDelayLabel = new QLabel(tr("Interphase Delay (DP): "));
     interphaseDelay = new TimeSpinBox(timestep_us);

--- a/source/stimparamdialog.h
+++ b/source/stimparamdialog.h
@@ -55,6 +55,7 @@ public slots:
 
 private:
     double calculateWaveformDuration();
+    double calculateActualSinglePulseDuration();
 
     QDialogButtonBox *buttonBox;
 
@@ -124,6 +125,10 @@ private:
 
     double timestep, currentstep, maxPulseDuration_us;
 
+    QGroupBox *singlePulseDuration;
+    QLabel *maxSinglePulseDurationLabel;
+    QLabel *actualSinglePulseDurationLabel;
+
 private slots:
     void enableWidgets();
     void calculateCharge();
@@ -132,6 +137,7 @@ private slots:
     void constrainPostStimChargeRecovery();
     void constrainRefractoryPeriod();
     void constrainPulseTrainPeriod();
+    void updateActualSinglePulseDuration();
     void roundTimeInputs();
     void roundCurrentInputs();
 

--- a/source/stimparamdialog.h
+++ b/source/stimparamdialog.h
@@ -54,6 +54,8 @@ public slots:
     void notifyFocusChanged(QWidget *lostFocus, QWidget *gainedFocus);
 
 private:
+    double calculateWaveformDuration();
+
     QDialogButtonBox *buttonBox;
 
     StimFigure *stimFigure;

--- a/source/stimparamdialog.h
+++ b/source/stimparamdialog.h
@@ -122,7 +122,7 @@ private:
     QLabel *postStimChargeRecovOffLabel;
     QCheckBox *enableChargeRecovery;
 
-    double timestep, currentstep;
+    double timestep, currentstep, maxPulseDuration_us;
 
 private slots:
     void enableWidgets();


### PR DESCRIPTION
Stim phase durations were capped at 5 ms in the StimParamDialog. This PR increases the maximum value these parameters can accept, up to a maximum compatible with hardware limitations. The user is notified if the sum of the durations is too large and is required to reduce the values.

![image](https://user-images.githubusercontent.com/241234/105566989-185a8980-5cfd-11eb-839d-4f17f771f3b8.png)